### PR TITLE
COMP: Add typescript types to "exports" in package.json

### DIFF
--- a/src/wasm/typescript/package.json
+++ b/src/wasm/typescript/package.json
@@ -7,6 +7,7 @@
   "types": "./dist/src/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/src/index.d.ts",
       "browser": "./dist/bundles/htj2k.js",
       "node": "./dist/bundles/htj2k.node.js",
       "default": "./dist/bundles/htj2k.js"


### PR DESCRIPTION
"types" outside exports is listed as a "fallback" per

https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing