### PR TITLE
COMP: Set `CMP0135` CMake policy to `NEW`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.16.3)
 project(IOOpenJPH)
 
+if(POLICY CMP0135)
+  cmake_policy(SET CMP0135 NEW)
+endif()
+
 set(IOOpenJPH_LIBRARIES IOOpenJPH)
 
 if(NOT ITK_SOURCE_DIR)


### PR DESCRIPTION
Set the `CMP0135` CMake policy to `NEW`: the timestamps of the extracted files will reflect the timestamps at extraction.

Fixes:
```
CMake Warning (dev) at D:/a/_temp/-2103337693/cmake-3.24.2-windows-x86_64/share/cmake-3.24/Modules/ExternalProject.cmake:3074 (message):
  The DOWNLOAD_EXTRACT_TIMESTAMP option was not given and policy CMP0135 is
  not set.  The policy's OLD behavior will be used.  When using a URL
  download, the timestamps of extracted files should preferably be that of
  the time of extraction, otherwise code that depends on the extracted
  contents might not be rebuilt if the URL changes.  The OLD behavior
  preserves the timestamps from the archive instead, but this is usually not
  what you want.  Update your project to the NEW behavior or specify the
  DOWNLOAD_EXTRACT_TIMESTAMP option with a value of true to avoid this
  robustness issue.
```

raised for example in:
https://open.cdash.org/build/9008260/configure

Related documentation:
https://cmake.org/cmake/help/latest/module/ExternalProject.html?highlight=download_extract_timestamp https://cmake.org/cmake/help/latest/policy/CMP0135.html